### PR TITLE
Fix #1:  Word Count works in firefox and chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,20 @@
             }
             
             function wordCount() {
-                var count = document.querySelector("#note").innerHTML.trim().replace(/  +/g, ' ').split(' ').length;
-                if (document.querySelector("#note").innerHTML.length == 0) count = 0;
+
+                var count = document.querySelector("#note").innerHTML.trim();
+                count = count.replace(/&nbsp;+/g, "");
+                count = count.replace(/<[^>]*>/g, " ");
+                count = count.replace(/\s+/g, " ");
+                count = count.split(" ");
+                var p = 0;
+                for( var i = 0; i < count.length; i++){
+                    if(count[i] == "")
+                        ++p;
+                }
+
+                count = count.length - p; 
+
                 document.querySelector("#wordNum").innerHTML = "Word Count: " + count; 
             }
 


### PR DESCRIPTION
Changed the Word Count function:

- `replace(/&nbsp;+/g, "")`
Prevents multiple spaces from creating a non-breaking space and adding to the word count by changing them into empty strings.

- `replace(/<[^>]*>/g, " ")`
Changes tags like \<br> and \<div> into spaces, this prevents them from adding to the word count when there are several with no words, but changes them into spaces so separate words get counted.

- `count.replace(/\s+/g, " ")`
Changes [white space characters](https://www.w3schools.com/jsref/jsref_regexp_whitespace.asp) into spaces

- ``for ( var i = 0; i < count.length; i++){
                    if(count[i] == "")
                        ++p;}``
Split() returns an empty string when there is nothing to split, an empty line will return 1. The white space characters will also return an empty string. This loop keeps track of the empty strings to subtract them from the final count
